### PR TITLE
Add custom index settings and mappings to Elasticsearch index

### DIFF
--- a/Command/BuildIndexCommand.php
+++ b/Command/BuildIndexCommand.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace FlexModel\FlexModelElasticsearchBundle\Command;
+
+use Elasticsearch\Client;
+use FlexModel\FlexModel;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * (Re-)builds the Elasticsearch index.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class BuildIndexCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('flexmodel:elasticsearch:build-index')
+            ->setDescription('(Re-)builds the Elasticsearch index.');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $indexName = $this->getContainer()
+            ->getParameter('flex_model.elasticsearch.index.name');
+
+        $io->section(sprintf('(Re-)building Elasticsearch index: %s', $indexName));
+
+        $client = $this->getContainer()->get('flex_model.elasticsearch.client');
+        /* @var $client Client */
+
+        $indexParameters = array(
+            'index' => $indexName,
+        );
+        if ($client->indices()->exists($indexParameters)) {
+            $io->text(sprintf('Elasticsearch index "%s" already exists. Deleting...', $indexName));
+
+            $client->indices()->delete($indexParameters);
+        }
+
+        $result = $client->indices()->create($this->getIndexCreationParameters($indexName));
+        if (isset($result['acknowledged']) && $result['acknowledged'] === true) {
+            $io->success('Created Elasticsearch index.');
+
+            $command = $this->getApplication()
+                ->find('flexmodel:elasticsearch:update-index');
+
+            return $command->run($input, $output);
+        }
+
+        $this->block('Failed creating Elasticsearch index.', 'FAILURE', 'fg=white;bg=red', ' ', true);
+    }
+
+    /**
+     * Returns the array with parameters for creating an Elasticsearch index with the proper settings and mappings.
+     *
+     * @param string $indexName
+     *
+     * @return array
+     */
+    private function getIndexCreationParameters($indexName)
+    {
+        $parameters = array(
+            'index' => $indexName,
+            'body' => array(
+                'settings' => $this->getContainer()
+                    ->getParameter('flex_model.elasticsearch.index.settings'),
+            ),
+        );
+
+        $indexMappings = array();
+
+        $flexModel = $this->getContainer()->get('flexmodel');
+        /* @var $flexModel FlexModel */
+
+        $objectNames = $flexModel->getObjectNames();
+        foreach ($objectNames as $objectName) {
+            $viewConfiguration = $flexModel->getViewConfiguration($objectName, 'searchindex');
+            if (isset($viewConfiguration)) {
+                foreach ($viewConfiguration['fields'] as $fieldConfiguration) {
+                    if (isset($fieldConfiguration['options'])) {
+                        $indexMappings[$objectName]['properties'][$fieldConfiguration['name']] = array(
+                            'type' => $this->getElasticsearchDatatype($fieldConfiguration['datatype']),
+                            'index' => 'not_analyzed',
+                        );
+                    }
+                }
+            }
+        }
+
+        $parameters['body']['mappings'] = array_replace_recursive(
+            $indexMappings,
+            $this->getContainer()
+                ->getParameter('flex_model.elasticsearch.index.mappings')
+        );
+
+        return $parameters;
+    }
+
+    /**
+     * Returns the FlexModel datatype equivalent for Elasticsearch.
+     *
+     * @param string $flexModelDatatype
+     *
+     * @return string
+     */
+    private function getElasticsearchDatatype($flexModelDatatype)
+    {
+        $datatype = strtolower($flexModelDatatype);
+        switch ($flexModelDatatype) {
+            case 'DATETIME':
+                $datatype = 'date';
+            case 'DATEINTERVAL':
+            case 'HTML':
+            case 'JSON':
+            case 'SET':
+            case 'TEXT':
+            case 'VARCHAR':
+                $datatype = 'string';
+                break;
+            case 'DECIMAL':
+                $datatype = 'double';
+                break;
+            case 'FILE':
+                $datatype = 'binary';
+                break;
+        }
+
+        return $datatype;
+    }
+}

--- a/Command/UpdateIndexCommand.php
+++ b/Command/UpdateIndexCommand.php
@@ -39,11 +39,7 @@ class UpdateIndexCommand extends ContainerAwareCommand
         $indexName = $this->getContainer()->getParameter('flex_model.elasticsearch.index.name');
         $indexParameters = array('index' => $indexName);
         if ($client->indices()->exists($indexParameters) === false) {
-            $client->indices()->create($indexParameters);
-
-            $io->text(sprintf('Created index "%s".', $indexName));
-        } else {
-            $io->text(sprintf('Index "%s" already exists. Continuing...', $indexName));
+            throw new RuntimeException(sprintf('Elasticsearch index "%s" does not exist.', $indexName));
         }
 
         $classMetaDataInstances = $this->getContainer()->get('doctrine')->getManager()->getMetadataFactory()->getAllMetadata();

--- a/Command/UpdateIndexCommand.php
+++ b/Command/UpdateIndexCommand.php
@@ -36,7 +36,7 @@ class UpdateIndexCommand extends ContainerAwareCommand
 
         $client = $this->getContainer()->get('flex_model.elasticsearch.client');
         /* @var $client \Elasticsearch\Client */
-        $indexName = $this->getContainer()->getParameter('flex_model.elasticsearch.index');
+        $indexName = $this->getContainer()->getParameter('flex_model.elasticsearch.index.name');
         $indexParameters = array('index' => $indexName);
         if ($client->indices()->exists($indexParameters) === false) {
             $client->indices()->create($indexParameters);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,12 +22,24 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('index')->end()
+                ->arrayNode('index')
+                    ->children()
+                        ->scalarNode('name')
+                            ->isRequired()
+                            ->end()
+                        ->variableNode('settings')
+                            ->defaultValue(array())
+                            ->end()
+                        ->variableNode('mappings')
+                            ->defaultValue(array())
+                            ->end()
+                        ->end()
+                    ->end()
                 ->arrayNode('hosts')
                     ->isRequired()
                     ->prototype('scalar')
-                ->end()
-            ->end();
+                    ->end()
+                ->end();
 
         return $treeBuilder;
     }

--- a/DependencyInjection/FlexModelElasticsearchExtension.php
+++ b/DependencyInjection/FlexModelElasticsearchExtension.php
@@ -22,7 +22,9 @@ class FlexModelElasticsearchExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter('flex_model.elasticsearch.index', strtolower($config['index']));
+        $container->setParameter('flex_model.elasticsearch.index.name', strtolower($config['index']['name']));
+        $container->setParameter('flex_model.elasticsearch.index.settings', $config['index']['settings']);
+        $container->setParameter('flex_model.elasticsearch.index.mappings', $config['index']['mappings']);
         $container->setParameter('flex_model.elasticsearch.hosts', $config['hosts']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/DependencyInjection/FlexModelElasticsearchFactory.php
+++ b/DependencyInjection/FlexModelElasticsearchFactory.php
@@ -22,8 +22,8 @@ class FlexModelElasticsearchFactory
     public static function createElasticsearchClient(array $hosts)
     {
         $client = ClientBuilder::create()
-                        ->setHosts($hosts)
-                        ->build();
+            ->setHosts($hosts)
+            ->build();
 
         return $client;
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -25,13 +25,13 @@
         <service id='flex_model.elasticsearch.indexer' class='%flex_model.elasticsearch.indexer.class%'>
             <argument type='service' id='flex_model.elasticsearch.client'/>
             <argument type='service' id='flexmodel'/>
-            <argument>%flex_model.elasticsearch.index%</argument>
+            <argument>%flex_model.elasticsearch.index.name%</argument>
         </service>
 
         <service id='flex_model.elasticsearch.filtered_searcher' class='%flex_model.elasticsearch.filtered_searcher.class%'>
             <argument type='service' id='flex_model.elasticsearch.client'/>
             <argument type='service' id='flexmodel'/>
-            <argument>%flex_model.elasticsearch.index%</argument>
+            <argument>%flex_model.elasticsearch.index.name%</argument>
         </service>
 
         <service id='flex_model.elasticsearch.aggregation_result_parser' class='%flex_model.elasticsearch.aggregation_result_parser.class%'>


### PR DESCRIPTION
This PR adds the following:
- Possibility to add custom Elasticsearch index settings and mappings.
- a `BuildIndexCommand` to create and fill a new index with the configured index settings and mappings.
