### PR TITLE
Add size parameter to return all values for a TermsAggregation bucket

### DIFF
--- a/Elasticsearch/FilteredSearcher.php
+++ b/Elasticsearch/FilteredSearcher.php
@@ -119,6 +119,7 @@ class FilteredSearcher
                     case 'SET':
                     case 'VARCHAR':
                         $aggregation = new TermsAggregation($fieldConfiguration['name'], $fieldConfiguration['name']);
+                        $aggregation->addParameter('size', 0);
                         break;
                 }
 


### PR DESCRIPTION
When documents contain many different terms, the bucket will not return all values by default. By adding a size parameter, all values for a `TermsAggregation` bucket are returned.